### PR TITLE
Migrate from ReactDOM.render to createRoot for compatibility with React 18+

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,8 +4,11 @@ import App from './App.jsx'
 import './index.css'
 import { BrowserRouter } from 'react-router-dom'
 
-ReactDOM.render(document.getElementById('root')).reder(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+const root = createRoot(document.getElementById('root'))
+root.render(
+  <StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>
 )


### PR DESCRIPTION
This PR addresses the migration from ReactDOM.render to createRoot in order to comply with React 18+ standards. The previous implementation was causing errors, as ReactDOM.render is deprecated in the latest React versions. The updated code utilizes createRoot from react-dom/client, wrapped in StrictMode and BrowserRouter, to render the App component without issues.

Changes:

- Updated index.js to use createRoot.
- Wrapped the rendering logic inside StrictMode to follow best practices.